### PR TITLE
Fix hardcoded Windows defaults for electrode locations and data path

### DIFF
--- a/pop_RELAX.m
+++ b/pop_RELAX.m
@@ -48,12 +48,13 @@ end
 
 % Specify your electrode locations with the correct cap file:
 if ~isfield(RELAX_cfg,'caploc')
-    RELAX_cfg.caploc='C:\Analysis_Tools\CapLocationFiles\standard-10-5-cap385.elp'; %path containing electrode positions
+    eeglab_dir = fileparts(which('eeglab'));
+    RELAX_cfg.caploc=fullfile(eeglab_dir, 'sample_locs', 'standard-10-5-cap385.elp'); %path containing electrode positions
 end
 
 % Specify the to be processed file locations:
 if ~isfield(RELAX_cfg,'myPath')
-    RELAX_cfg.myPath='C:\DATA_TO_BE_PREPROCESSED\';
+    RELAX_cfg.myPath=[pwd filesep];
 end
 
 % Specify whether all data is in a single folder or data are in BIDS format


### PR DESCRIPTION
## Summary

Replace the two hardcoded Windows absolute paths that are used as defaults in `pop_RELAX.m` when `RELAX_cfg.caploc` or `RELAX_cfg.myPath` have not been set by the user.

## Changes

- **Electrode locations (`caploc`)**:  
  Previously hard-coded to  
  `C:\Analysis_Tools\CapLocationFiles\standard-10-5-cap385.elp`  
  Now resolves the EEGLAB installation directory and points to the standard sample locations file that ships with EEGLAB:
  ```matlab
  eeglab_dir = fileparts(which('eeglab'));
  RELAX_cfg.caploc = fullfile(eeglab_dir, 'sample_locs', 'standard-10-5-cap385.elp');